### PR TITLE
STEP04. 사용자의 동일 수강 재신청시 제한 구현

### DIFF
--- a/lecture-tdd-api/src/main/java/io/hhplus/tdd/application/course/CourseService.java
+++ b/lecture-tdd-api/src/main/java/io/hhplus/tdd/application/course/CourseService.java
@@ -16,6 +16,7 @@ public class CourseService {
     }
 
     public void enrollUser(long userId, long lectureNo) {
+        validateEnrollment(userId, lectureNo);
         CourseEntity course = CourseEntity.builder()
                 .userId(userId)
                 .lectureNo(lectureNo)
@@ -23,6 +24,16 @@ public class CourseService {
                 .build();
 
         jpaCourseRepository.save(course);
+    }
+
+    public boolean checkUserAlreadyEnrolled(long userId, long lectureNo) {
+        return jpaCourseRepository.existsByUserIdAndLectureNo(userId, lectureNo);
+    }
+
+    public void validateEnrollment(long userId, long lectureNo) {
+        if (checkUserAlreadyEnrolled(userId, lectureNo)) {
+            throw new IllegalArgumentException("이미 신청된 강의");
+        }
     }
 
 }

--- a/lecture-tdd-api/src/main/java/io/hhplus/tdd/application/facade/EnrollmentFacade.java
+++ b/lecture-tdd-api/src/main/java/io/hhplus/tdd/application/facade/EnrollmentFacade.java
@@ -24,6 +24,11 @@ public class EnrollmentFacade {
         return lectureService.getLectureList();
     }
 
+    // 강의 신청 유무 확인
+    public void validateEnrollment(long userId, long lectureNo) {
+        courseService.validateEnrollment(userId, lectureNo);
+    }
+
     // 강의 등록
     @Transactional
     public void enrollUser(long userId, long lectureNo) {

--- a/lecture-tdd-api/src/test/java/io/hhplus/tdd/application/facade/EnrollmentFacadeTest.java
+++ b/lecture-tdd-api/src/test/java/io/hhplus/tdd/application/facade/EnrollmentFacadeTest.java
@@ -77,4 +77,25 @@ public class EnrollmentFacadeTest {
         assertEquals(30, updatedLectureEntity.getApplyCnt());
     }
 
+    // 통합 테스트 02 : 중복 수강 신청
+    @Test
+    public void testApplyMulti() {
+        // given
+        long userId = 1L;
+        long lectureNo = 1L;
+
+        // when
+        enrollmentFacade.enrollUser(userId, lectureNo);
+
+        for (int i = 0; i < 4; i++) {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                enrollmentFacade.enrollUser(userId, lectureNo);
+            });
+            assertEquals("이미 신청된 강의", exception.getMessage());
+        }
+
+        boolean isEnrolled = jpaCourseRepository.existsByUserIdAndLectureNo(userId, lectureNo);
+        assertTrue(isEnrolled);
+    }
+
 }


### PR DESCRIPTION
### **작업 내역**
**STEP04**
1. CourseService
   - 동일한 아이디 중복 수강 신청 제한 구현
2. EnrollmentFacade
   - CourseService 내 동일한 아이디 중복 수강 신청 제한 적용
3. EnrollmentFacadeTest
   - 동일한 아이디 중복 수강 신청 제한 테스트 구현

### **PR**
- STEP04
   - [#180ff22](https://github.com/soumunda8/HH99-WEEK02/commit/180ff227d8ed6bedc46e8044762b38b6134d14d0) - 테스트